### PR TITLE
add initial KPI framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,22 @@ From command line:
 # fetch version
 pywcmp --version
 
+# abstract test suite
+
 # validate metadata against abstract test suite (file on disk)
-pywcmp validate ats --file /path/to/file.xml
+pywcmp ats validate --file /path/to/file.xml
 
 # validate metadata against abstract test suite (URL)
-pywcmp validate ats --url http://example.org/path/to/file.xml
+pywcmp ats validate --url http://example.org/path/to/file.xml
 
 # adjust debugging messages (CRITICAL, ERROR, WARNING, INFO, DEBUG) to stdout
-pywcmp validate ats --url http://example.org/path/to/file.xml --verbosity DEBUG
+pywcmp ats validate --url http://example.org/path/to/file.xml --verbosity DEBUG
 
 # write results to logfile
-pywcmp validate ats --url http://example.org/path/to/file.xml --verbosity DEBUG --logfile /tmp/foo.txt
+pywcmp ats validate --url http://example.org/path/to/file.xml --verbosity DEBUG --logfile /tmp/foo.txt
+
+# key performance indicators # note: running KPIs automatically runs the ats
+pywcmp kpi validate --url http://example.org/path/to/file.xml --verbosity DEBUG
 ```
 
 ## Using the API
@@ -59,6 +64,9 @@ pywcmp validate ats --url http://example.org/path/to/file.xml --verbosity DEBUG 
 ... except ats.TestSuiteError as err:
 ...    print('\n'.join(err.errors))
 >>> ...
+>>> from pywcmp.kpi import WMOCoreMetadataProfileKeyPerformanceIndicators
+>>> kpis = WMOCoreMetadataProfileKeyPerformanceIndicators(exml)
+>>> kpis['totals']
 ```
 
 ## Development

--- a/pywcmp/__init__.py
+++ b/pywcmp/__init__.py
@@ -18,7 +18,7 @@
 # those files. Users are asked to read the 3rd Party Licenses
 # referenced with those assets.
 #
-# Copyright (c) 2019 Government of Canada
+# Copyright (c) 2020 Government of Canada
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -46,16 +46,9 @@
 import click
 
 from pywcmp.ats import ats
+from pywcmp.kpi import kpi
 
 __version__ = '0.2.dev0'
-
-
-@click.group()
-def validate():
-    pass
-
-
-validate.add_command(ats)
 
 
 @click.group()
@@ -64,4 +57,5 @@ def cli():
     pass
 
 
-cli.add_command(validate)
+cli.add_command(ats)
+cli.add_command(kpi)

--- a/pywcmp/ats.py
+++ b/pywcmp/ats.py
@@ -18,7 +18,7 @@
 # those files. Users are asked to read the 3rd Party Licenses
 # referenced with those assets.
 #
-# Copyright (c) 2019 Government of Canada
+# Copyright (c) 2020 Government of Canada
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -59,7 +59,7 @@ LOGGER = logging.getLogger(__name__)
 CODELIST_PREFIX = 'http://wis.wmo.int/2012/codelists/WMOCodeLists.xml'
 
 
-def msg(test_id, test_description):
+def msg(test_id: str, test_description: str) -> str:
     """
     Convenience function to print test props
 
@@ -73,7 +73,7 @@ def msg(test_id, test_description):
     return 'Requirement {}:\n    {}'.format(requirement, test_description)
 
 
-def gen_test_id(test_id):
+def gen_test_id(test_id: str) -> str:
     """
     Convenience function to print test identifier as URI
 
@@ -85,7 +85,7 @@ def gen_test_id(test_id):
     return 'http://wis.wmo.int/2012/metadata/conf/{}'.format(test_id)
 
 
-class WMOCoreMetadataProfileTestSuite13(object):
+class WMOCoreMetadataProfileTestSuite13:
     """Test suite for WMO Core Metadata Profile assertions"""
 
     def __init__(self, exml):
@@ -94,7 +94,7 @@ class WMOCoreMetadataProfileTestSuite13(object):
 
         :param exml: `etree.ElementTree` object
 
-        :returns: `pywcmp.WMOCoreMetadataProfileTestSuite13`
+        :returns: `pywcmp.ats.WMOCoreMetadataProfileTestSuite13`
         """
 
         self.test_id = None
@@ -270,7 +270,7 @@ class WMOCoreMetadataProfileTestSuite13(object):
                 count += 1
         assert(count == 1), self.test_requirement_9_3_2.__doc__
 
-    def _get_wmo_keyword_lists(self, code='WMO_CategoryCode'):
+    def _get_wmo_keyword_lists(self, code: str = 'WMO_CategoryCode') -> list:
         """
         Helper function to retrieve all keyword sets by code
 
@@ -297,7 +297,7 @@ class WMOCoreMetadataProfileTestSuite13(object):
                         wmo_cats.append(kwd)
         return wmo_cats
 
-    def _get_keyword_values(self, keyword_nodes):
+    def _get_keyword_values(self, keyword_nodes: list) -> list:
         values = []
         for keyword_node in keyword_nodes:
             anchor_node = keyword_node.find(nspath_eval('gmx:Anchor'))
@@ -319,6 +319,12 @@ class TestSuiteError(Exception):
         self.errors = errors
 
 
+@click.group()
+def ats():
+    """abstract test suite"""
+    pass
+
+
 @click.command()
 @click.pass_context
 @get_cli_common_options
@@ -327,8 +333,8 @@ class TestSuiteError(Exception):
               help='Path to XML file')
 @click.option('--url', '-u',
               help='URL of XML file')
-def ats(ctx, file_, url, logfile, verbosity):
-    """command line interface"""
+def validate(ctx, file_, url, logfile, verbosity):
+    """validate against the abstract test suite"""
 
     if file_ is None and url is None:
         raise click.UsageError('Missing --file or --url options')
@@ -354,3 +360,6 @@ def ats(ctx, file_, url, logfile, verbosity):
     except TestSuiteError as err:
         msg = '\n'.join(err.errors)
         print(msg)
+
+
+ats.add_command(validate)

--- a/pywcmp/kpi.py
+++ b/pywcmp/kpi.py
@@ -1,0 +1,165 @@
+# =================================================================
+#
+# Terms and Conditions of Use
+#
+# Unless otherwise noted, computer program source code of this
+# distribution is covered under Crown Copyright, Government of
+# Canada, and is distributed under the MIT License.
+#
+# The Canada wordmark and related graphics associated with this
+# distribution are protected under trademark law and copyright law.
+# No permission is granted to use them outside the parameters of
+# the Government of Canada's corporate identity program. For
+# more information, see
+# http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
+#
+# Copyright title to all 3rd party software distributed with this
+# software is held by the respective copyright holders as noted in
+# those files. Users are asked to read the 3rd Party Licenses
+# referenced with those assets.
+#
+# Copyright (c) 2020 Government of Canada
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+# WMO Core Metadata Profile Key Performance Indicators (KPIs)
+
+import logging
+from io import StringIO
+
+import click
+from lxml import etree
+
+from pywcmp.ats import TestSuiteError, WMOCoreMetadataProfileTestSuite13
+from pywcmp.util import (get_cli_common_options, get_codelists, setup_logger,
+                         urlopen_)
+
+LOGGER = logging.getLogger(__name__)
+# round percentages to x decimal places
+ROUND = 3
+
+
+class WMOCoreMetadataProfileKeyPerformanceIndicators:
+    """Key Performance Indicators for WMO Core Metadata Profile"""
+
+    def __init__(self, exml):
+        """
+        initializer
+
+        :param exml: `etree.ElementTree` object
+
+        :returns: `pywcmp.kpi.WMOCoreMetadataProfileKeyPerformanceIndicators`
+        """
+
+        self.exml = exml  # serialized already
+        self.namespaces = self.exml.getroot().nsmap
+
+        # generate dict of codelists
+        self.codelists = get_codelists()
+
+    def kpi_a(self) -> tuple:
+        ts = WMOCoreMetadataProfileTestSuite13(self.exml)
+
+        total = 1
+
+        # run the tests
+        try:
+            ts.run_tests()
+            score = 1
+        except TestSuiteError:
+            score = 0
+
+        return total, score
+
+    def evaluate(self) -> dict:
+        """Convenience function to run all tests"""
+
+        kpis_to_run = ['kpi_a']
+
+        results = {}
+
+        for k in kpis_to_run:
+            LOGGER.debug('Running {}'.format(k))
+            result = getattr(self, k)()
+            LOGGER.debug('Calculating result')
+            percentage = round(float((result[1] / result[0]) * 100), ROUND)
+
+            results[k] = {
+                'total': result[0],
+                'score': result[1],
+                'percentage': percentage
+            }
+
+        LOGGER.debug('Calculating total results')
+        sum_total = sum(v['total'] for k, v in results.items())
+        sum_score = sum(v['score'] for k, v in results.items())
+        sum_percentage = round(float((sum_score / sum_total) * 100), ROUND)
+
+        results['totals'] = {
+            'total': sum_total,
+            'score': sum_score,
+            'percentage': sum_percentage
+        }
+
+        return results
+
+
+@click.group()
+def kpi():
+    """key performance indicators"""
+    pass
+
+
+@click.command()
+@click.pass_context
+@get_cli_common_options
+@click.option('--file', '-f', 'file_',
+              type=click.Path(exists=True, resolve_path=True),
+              help='Path to XML file')
+@click.option('--url', '-u',
+              help='URL of XML file')
+def validate(ctx, file_, url, logfile, verbosity):
+    """run key performance indicators"""
+
+    if file_ is None and url is None:
+        raise click.UsageError('Missing --file or --url options')
+
+    setup_logger(verbosity, logfile)
+
+    if file_ is not None:
+        content = file_
+        msg = 'Validating file {}'.format(file_)
+        LOGGER.info(msg)
+        click.echo(msg)
+    elif url is not None:
+        content = StringIO(urlopen_(content).read())
+
+    exml = etree.parse(content)
+
+    kpis = WMOCoreMetadataProfileKeyPerformanceIndicators(exml)
+
+    click.echo(kpis.evaluate()['totals'])
+
+
+kpi.add_command(validate)

--- a/pywcmp/util.py
+++ b/pywcmp/util.py
@@ -18,7 +18,7 @@
 # those files. Users are asked to read the 3rd Party Licenses
 # referenced with those assets.
 #
-# Copyright (c) 2019 Government of Canada
+# Copyright (c) 2020 Government of Canada
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -97,7 +97,7 @@ def get_codelists():
     return codelists
 
 
-def get_userdir():
+def get_userdir() -> str:
     """
     Helper function to get userdir
 
@@ -107,7 +107,7 @@ def get_userdir():
     return '{}{}{}'.format(os.path.expanduser('~'), os.sep, '.pywcmp')
 
 
-def nspath_eval(xpath):
+def nspath_eval(xpath: str) -> str:
     """
     Return an etree friendly xpath based expanding namespace
     into namespace URIs
@@ -124,7 +124,7 @@ def nspath_eval(xpath):
     return '/'.join(out)
 
 
-def setup_logger(loglevel=None, logfile=None):
+def setup_logger(loglevel: str = None, logfile: str = None):
     """
     Setup logging
 
@@ -164,7 +164,7 @@ def setup_logger(loglevel=None, logfile=None):
         LOGGER.debug('Logging initialized')
 
 
-def urlopen_(url):
+def urlopen_(url: str):
     """
     Helper function for downloading a URL
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -48,6 +48,7 @@ import unittest
 
 from lxml import etree
 from pywcmp.ats import TestSuiteError, WMOCoreMetadataProfileTestSuite13
+from pywcmp.kpi import WMOCoreMetadataProfileKeyPerformanceIndicators
 
 
 def get_test_file_path(filename):
@@ -59,8 +60,9 @@ def get_test_file_path(filename):
         return 'tests/{}'.format(filename)
 
 
-class WmoTestSuiteTest(unittest.TestCase):
-    """Test suite for package Foo"""
+class WCMPATSTest(unittest.TestCase):
+    """WCMP ATS tests of tests"""
+
     def setUp(self):
         """setup test fixtures, etc."""
         pass
@@ -84,6 +86,29 @@ class WmoTestSuiteTest(unittest.TestCase):
             ts.run_tests()
         except TestSuiteError as err:
             self.assertEqual(3, len(err.errors))
+
+
+class WCMPKPITest(unittest.TestCase):
+    """WCMP KPI tests of tests"""
+
+    def setUp(self):
+        """setup test fixtures, etc."""
+        pass
+
+    def tearDown(self):
+        """return to pristine state"""
+        pass
+
+    def test_kpi_evaluate(self):
+        exml = etree.parse(get_test_file_path('data/urn:x-wmo:md:int.wmo.wis::ca.gc.ec.msc-1.1.5.6.xml'))  # noqa
+
+        kpis = WMOCoreMetadataProfileKeyPerformanceIndicators(exml)
+
+        results = kpis.evaluate()
+
+        self.assertEqual(results['totals']['total'], 1)
+        self.assertEqual(results['totals']['score'], 1)
+        self.assertEqual(results['totals']['percentage'], 100.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds a simple KPI framework which can be run via the command line or from a downstream Python application.

The basic idea is that `pywcmp/kpi:WMOCoreMetadataProfileKeyPerformanceIndicators` will implement all the approved KPIs as functions which return a tuple of total and score. `pywcmp/kpi:WMOCoreMetadataProfileKeyPerformanceIndicators.run_kpis()` runs all the KPIs and calculates a total raw score as well as total percentage, returned as a `dict`.  This allows for reporting to the CLI on stdout, or in a downstream application.

In addition, a number of small changes (function annotations, etc.) for housekeeping are added.