### PR TITLE
improve spellchecking (#29)

### DIFF
--- a/pywcmp/dictionary.txt
+++ b/pywcmp/dictionary.txt
@@ -1,0 +1,2 @@
+# add custom dictionary words below (one per line)
+# as part of spellchecker functionality

--- a/setup.py
+++ b/setup.py
@@ -157,7 +157,7 @@ setup(
     url='https://github.com/wmo-im/pywcmp',
     install_requires=read('requirements.txt').splitlines(),
     packages=find_packages(),
-    # package_data=PACKAGE_DATA,
+    package_data={'pywcmp': ['dictionary.txt']},
     entry_points={
         'console_scripts': [
             'pywcmp=pywcmp:cli'

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -108,8 +108,8 @@ class WCMPKPITest(unittest.TestCase):
         results = kpis.evaluate()
 
         self.assertEqual(results['summary']['total'], 46)
-        self.assertEqual(results['summary']['score'], 28)
-        self.assertEqual(results['summary']['percentage'], 60.870)
+        self.assertEqual(results['summary']['score'], 29)
+        self.assertEqual(results['summary']['percentage'], 63.043)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #29

- improves spellchecking to account for natural sentences (periods, brackets, etc.)
- refactors KPI-2 and KPI-3 to use a central `_check_spelling` function
- introduces custom dictionary which we can add to over time for esoteric/domain specific words that should fail a spellcheck