### PR TITLE
Change scoring for bulletin heading check in KPI-3 #75

### DIFF
--- a/pywcmp/kpi.py
+++ b/pywcmp/kpi.py
@@ -301,7 +301,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         for a in abstracts:
             abstract = a.text
             LOGGER.debug('Abstract is present')
-            total += 3
+            total += 4
 
             if abstract is None:
                 comments.append(f'Abstract at line {a.sourceline}: is null')
@@ -321,8 +321,9 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
 
             LOGGER.debug('Testing for bulletin headers')
             has_bulletin_header = re.search(r'[A-Z]{4}\d{2}[\s_]*[A-Z]{4}', abstract)
-            if has_bulletin_header:
-                score -= 1
+            if not has_bulletin_header:
+                score += 1
+            else:
                 comments.append(f'Line {a.sourceline}: contains bulletin header')
 
             LOGGER.debug('Testing for spelling')

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -109,9 +109,9 @@ class WCMPKPITest(unittest.TestCase):
 
         results = kpis.evaluate()
 
-        self.assertEqual(results['summary']['total'], 63)
-        self.assertEqual(results['summary']['score'], 40)
-        self.assertEqual(results['summary']['percentage'], 63.492)
+        self.assertEqual(results['summary']['total'], 64)
+        self.assertEqual(results['summary']['score'], 41)
+        self.assertEqual(results['summary']['percentage'], 64.062)
         self.assertEqual(results['summary']['grade'], "C")
 
     def test_calculate_grade(self):


### PR DESCRIPTION
Instead of the total score of 3 out of 4 tests, where the last one gives either 0 or -1 point, the total is no 4 and the bulletin heading test works the same way as other tests, i.e. it gives either +1 or 0.