### PR TITLE
Fix and relax DOI checking #86

### DIFF
--- a/pywcmp/kpi.py
+++ b/pywcmp/kpi.py
@@ -425,7 +425,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         :returns: `tuple` of KPI name, achieved score, total score, and comments
         """
 
-        total = 3
+        total = 0
         score = 0
         comments = []
 
@@ -438,8 +438,9 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         LOGGER.debug(f'Testing all DOIs at {xpath}')
 
         doi_anchors = self.exml.xpath(xpath, namespaces=self.namespaces)
-
-        for doi_anchor in doi_anchors:
+        
+        if len(doi_anchors) > 0:
+            doi_anchor = doi_anchors[0]
             LOGGER.debug('DOI anchor is present')
             # TODO: KPI def does not check for actual value
             total += 3

--- a/pywcmp/kpi.py
+++ b/pywcmp/kpi.py
@@ -438,7 +438,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         LOGGER.debug(f'Testing all DOIs at {xpath}')
 
         doi_anchors = self.exml.xpath(xpath, namespaces=self.namespaces)
-        
+
         if len(doi_anchors) > 0:
             doi_anchor = doi_anchors[0]
             LOGGER.debug('DOI anchor is present')

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -110,9 +110,9 @@ class WCMPKPITest(unittest.TestCase):
 
         results = kpis.evaluate()
 
-        self.assertEqual(results['summary']['total'], 63)
+        self.assertEqual(results['summary']['total'], 60)
         self.assertEqual(results['summary']['score'], 41)
-        self.assertEqual(results['summary']['percentage'], 65.079)
+        self.assertEqual(results['summary']['percentage'], 68.333)
         self.assertEqual(results['summary']['grade'], "B")
 
     def test_calculate_grade(self):


### PR DESCRIPTION
The total score for KPI-005 (DOI) is now 3 (not a multiple of it) and only the first matching element is checked. Moreover, if no element is found the total score for this KPI is set to 0 (zero).