### PR TITLE
fix immediate schema validation failure/exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ pywcmp ets validate https://example.org/path/to/file.xml
 # validate WCMP 2 metadata against abstract test suite (URL)
 pywcmp ets validate https://example.org/path/to/file.json
 
+# validate WCMP 2 metadata against abstract test suite (URL), but turn JSON Schema validation off
+pywcmp ets validate https://example.org/path/to/file.json --no-fail-on-schema-validation
+
 # adjust debugging messages (CRITICAL, ERROR, WARNING, INFO, DEBUG) to stdout
 pywcmp ets validate https://example.org/path/to/file.xml --verbosity DEBUG
 

--- a/pywcmp/ets.py
+++ b/pywcmp/ets.py
@@ -50,7 +50,8 @@ def ets():
 @click.pass_context
 @get_cli_common_options
 @click.argument('file_or_url')
-@click.option('--fail-on-schema-validation', '-f', is_flag=True, default=False,
+@click.option('--fail-on-schema-validation/--no-fail-on-schema-validation',
+              '-f', default=True,
               help='Stop the ETS on failing schema validation')
 def validate(ctx, file_or_url, logfile, verbosity,
              fail_on_schema_validation=True):

--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -82,7 +82,8 @@ class WMOCoreMetadataProfileTestSuite2:
         if validation_result['code'] == 'FAILED':
             if fail_on_schema_validation:
                 msg = 'Record fails WCMP2 validation. Stopping ETS'
-                LOGGER.error(msg)
+                msg += f"Validation error: {validation_result['message']}"
+                LOGGER.info(msg)
                 raise ValueError(msg)
 
         for t in tests:
@@ -106,7 +107,7 @@ class WMOCoreMetadataProfileTestSuite2:
 
         if not schema.exists():
             msg = "WCMP2 schema missing. Run 'pywcmp bundle sync' to cache"
-            LOGGER.error(msg)
+            LOGGER.info(msg)
             raise RuntimeError(msg)
 
         LOGGER.debug(f'Validating {self.record} against {schema}')

--- a/pywcmp/wcmp2/topics.py
+++ b/pywcmp/wcmp2/topics.py
@@ -129,7 +129,7 @@ class TopicHierarchy:
 
         if not self.validate(th):
             msg = 'Invalid topic'
-            LOGGER.error(msg)
+            LOGGER.info(msg)
             raise ValueError(msg)
 
         th = rstrip_add(topic_hierarchy, pad_again=True)
@@ -143,7 +143,7 @@ class TopicHierarchy:
 
         if not matches:
             msg = f'No matching topics for {topic_hierarchy}'
-            LOGGER.error(msg)
+            LOGGER.info(msg)
             raise ValueError(msg)
 
         return list(set(matches))
@@ -163,7 +163,7 @@ class TopicHierarchy:
 
         if topic_hierarchy is None:
             msg = 'Topic hierarchy is empty'
-            LOGGER.error(msg)
+            LOGGER.info(msg)
             raise ValueError(msg)
 
         if fuzzy:


### PR DESCRIPTION
Fixes flags to (by default) fail immediately when a WCMP2 document is not JSON Schema valid.  To force continue with the ETS, add the `--no-fail-on-schema-validation` flag.

cc @jsieland @antje-s 