### PR TITLE
add generated-by to reports

### DIFF
--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from jsonschema.validators import Draft202012Validator
 
+import pywcmp
 from pywcmp.bundle import WCMP2_FILES
 from pywis_topics.topics import TopicHierarchy
 from pywcmp.util import get_current_datetime_rfc3339, get_userdir
@@ -76,6 +77,7 @@ class WMOCoreMetadataProfileTestSuite2:
         tests = []
         ets_report = {
             'summary': {},
+            'generated-by': f'pywcmp {pywcmp.__version__} (https://github.com/wmo-im/pywcmp)'  # noqa
         }
 
         for f in dir(WMOCoreMetadataProfileTestSuite2):

--- a/pywcmp/wcmp2/kpi.py
+++ b/pywcmp/wcmp2/kpi.py
@@ -31,6 +31,7 @@ import re
 
 from bs4 import BeautifulSoup
 
+import pywcmp
 from pywcmp.util import (check_spelling, check_url,
                          get_current_datetime_rfc3339)
 
@@ -515,6 +516,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         results['summary']['grade'] = overall_grade
 
         results['datetime'] = get_current_datetime_rfc3339()
+        results['generated-by'] = f'pywcmp {pywcmp.__version__} (https://github.com/wmo-im/pywcmp)'  # noqa
 
         return results
 


### PR DESCRIPTION
As discussed at a WIS2 monitoring meeting today, given some GDCs will provide ETS and KPI reports to Global Monitoring, it might be useful to have metadata added to ETS/KPI reports to identify what tool(s) generated a given report in the GDC/WCMP2 context (cc @maaikelimper).