### PR TITLE
ETS: creation date fix

### DIFF
--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -26,6 +26,7 @@
 # executable test suite as per WMO Core Metadata Profile 2, Annex A
 
 import csv
+from datetime import datetime
 import json
 import logging
 from pathlib import Path
@@ -370,9 +371,16 @@ class WMOCoreMetadataProfileTestSuite2:
 
         status = {
             'id': gen_test_id('record_creation_date'),
-            'code': 'PASSED',
-            'message': 'Passes given schema is compliant/valid'
+            'code': 'PASSED'
         }
+
+        created = self.record['properties']['created']
+
+        try:
+            datetime.strptime(created, '%Y-%m-%dT%H:%M:%S%z')
+        except ValueError:
+            status['code'] = 'FAILED'
+            status['message'] = 'Invalid date-time format'
 
         return status
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ beautifulsoup4
 click
 jsonschema>4.19
 pyspellchecker
-python-dateutil
 pywis-topics

--- a/tests/data/wcmp2-failing-created-none.json
+++ b/tests/data/wcmp2-failing-created-none.json
@@ -1,13 +1,14 @@
 {
     "id": "urn:wmo:md:ca-eccc-msc:weather.observations.swob-realtime",
     "conformsTo": [
-        "bad-uri"
+        "http://wis.wmo.int/spec/wcmp/2/conf/core"
     ],
     "time": {
         "interval": [
             "2010-11-11T11:11:11Z",
             ".."
-        ]
+        ],
+        "resolution": "P1H"
     },
     "type": "Feature",
     "geometry": {
@@ -38,7 +39,7 @@
         ]
     },
     "properties": {
-        "title": "Surface Weather Observations",
+        "title": "Surface weather observations",
         "description": "Surface Observations measured at the automatic and manual stations of the Environment and Climate Change Canada and partners networks, either for a single station, or for the stations of specific provinces and territories (last 30 days)",
         "themes": [
             {
@@ -67,7 +68,8 @@
                     {
                         "id": "Meteorological data"
                     }
-                ]
+                ],
+                "scheme": "https://library-archives.canada.ca/eng/services/government-canada/controlled-vocabularies-government-canada/pages/controlled-vocabularies-government-canada.aspx"
             },
             {
                 "concepts": [
@@ -80,7 +82,7 @@
         ],
         "contacts": [
             {
-                "name": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
+                "organization": "Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada",
                 "position": "National Inquiry Response Team",
                 "phones": [
                     {
@@ -107,17 +109,20 @@
                     {
                         "rel": "canonical",
                         "type": "text/html",
-                        "href": "https://www.canada.ca/en/environment-climate-change.html"
+                        "href": "https://example.org"
                     }
                 ],
+                "contactInstructions": "via email",
                 "roles": [
-                    "processor"
+                    "host",
+                    "producer"
                 ]
             }
         ],
         "type": "dataset",
-        "created": "2018-01-01T21:24:45Z",
-        "updated": "2022-06-22T08:22:48Z"
+        "created": "None",
+        "updated": "2022-06-22",
+        "wmo:dataPolicy": "core"
     },
     "links": [
         {
@@ -127,7 +132,7 @@
             "title": "Stations associated with this dataset"
         },
         {
-            "rel": "download",
+            "rel": "data",
             "href": "https://dd.weather.gc.ca/observations/swob-ml",
             "type": "text/html",
             "hreflang": "en",

--- a/tests/data/wcmp2-passing.json
+++ b/tests/data/wcmp2-passing.json
@@ -120,8 +120,8 @@
             }
         ],
         "type": "dataset",
-        "created": "2018-01-01",
-        "updated": "2022-06-22",
+        "created": "2018-01-01T11:11:11Z",
+        "updated": "2022-06-22T12:42:46Z",
         "wmo:dataPolicy": "core"
     },
     "links": [

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -58,6 +58,7 @@ class WCMP2ETSTest(unittest.TestCase):
 
     def test_pass(self):
         """Simple tests for a passing record"""
+
         with open(get_test_file_path('data/wcmp2-passing.json')) as fh:
             ts = WMOCoreMetadataProfileTestSuite2(json.load(fh))
             results = ts.run_tests()
@@ -70,6 +71,7 @@ class WCMP2ETSTest(unittest.TestCase):
 
     def test_fail(self):
         """Simple tests for a failing record"""
+
         with open(get_test_file_path('data/wcmp2-failing.json')) as fh:
             record = json.load(fh)
             ts = WMOCoreMetadataProfileTestSuite2(record)
@@ -84,6 +86,20 @@ class WCMP2ETSTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 ts.run_tests(fail_on_schema_validation=True)
 
+    def test_fail_created_none(self):
+        """Simple tests for a failing record with an invalid creation date"""
+
+        with open(get_test_file_path('data/wcmp2-failing-created-none.json')) as fh:  # noqa
+            record = json.load(fh)
+            ts = WMOCoreMetadataProfileTestSuite2(record)
+            results = ts.run_tests()
+
+            codes = [r['code'] for r in results['ets-report']['tests']]
+
+            self.assertEqual(codes.count('FAILED'), 1)
+            self.assertEqual(codes.count('PASSED'), 11)
+            self.assertEqual(codes.count('SKIPPED'), 0)
+
 
 class WCMP2KPITest(unittest.TestCase):
     """WCMP KPI tests of tests"""
@@ -97,6 +113,8 @@ class WCMP2KPITest(unittest.TestCase):
         pass
 
     def test_kpi_evaluate(self):
+        """Tests for KPI evaluation"""
+
         file_ = 'data/wcmp2-passing.json'
         with open(get_test_file_path(file_)) as fh:
             data = json.load(fh)


### PR DESCRIPTION
This PR adds tighter checking of `properties.created` based on the RFC3339 requirement of WCMP2 / OGC API - Records.

Note:

The JSON schema specification specifies dates as a format (vs. a type), for example:

```json
"type": "string",
"format": "date-time"
```

jsonschema validation, by default, does not check against `format` specifications, but does provide a `FormatChecker` that can check JSON Schema `format`s if they are defined in a property.  For `date-time` formats, this requires the [rfc3339-validator](https://pypi.org/project/rfc3339-validator/) package.  I've decided to implement this in the ETS so as not to add another dependency.