### PR TITLE
safeguard KPI checks against empty links

### DIFF
--- a/pywcmp/wcmp2/kpi.py
+++ b/pywcmp/wcmp2/kpi.py
@@ -349,7 +349,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
             })
 
         for contact in self.data['properties']['contacts']:
-            for link in contact['links']:
+            for link in contact.get('links', []):
                 links.append({
                     'href': link['href']
                 })


### PR DESCRIPTION
Fixes KPI checks when links are an optional property of `properties.contacts`.