### PR TITLE
align ETS and KPI report formats, add UUID and metadata to reports

### DIFF
--- a/pywcmp/ets.py
+++ b/pywcmp/ets.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Ján Osuský <jan.osusky@iblsoft.com>
 #
-# Copyright (c) 2023 Tom Kralidis
+# Copyright (c) 2024 Tom Kralidis
 # Copyright (c) 2022 Government of Canada
 # Copyright (c) 2020 IBL Software Engineering spol. s r. o.
 #
@@ -81,7 +81,7 @@ def validate(ctx, file_or_url, logfile, verbosity,
         ctx.exit(1)
 
     click.echo(json.dumps(results, indent=4))
-    ctx.exit(results['ets-report']['summary']['FAILED'])
+    ctx.exit(results['summary']['FAILED'])
 
 
 ets.add_command(validate)

--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -29,6 +29,7 @@ import csv
 import json
 import logging
 from pathlib import Path
+import uuid
 
 from jsonschema.validators import Draft202012Validator
 
@@ -67,7 +68,6 @@ class WMOCoreMetadataProfileTestSuite2:
 
         self.test_id = None
         self.record = data
-        self.report = []
 
         self.th = TopicHierarchy(tables=get_userdir())
 
@@ -77,8 +77,10 @@ class WMOCoreMetadataProfileTestSuite2:
         results = []
         tests = []
         ets_report = {
+            'id': str(uuid.uuid4()),
+            'report_type': 'ets',
             'summary': {},
-            'generated-by': f'pywcmp {pywcmp.__version__} (https://github.com/wmo-im/pywcmp)'  # noqa
+            'generated_by': f'pywcmp {pywcmp.__version__} (https://github.com/wmo-im/pywcmp)'  # noqa
         }
 
         for f in dir(WMOCoreMetadataProfileTestSuite2):
@@ -106,10 +108,9 @@ class WMOCoreMetadataProfileTestSuite2:
 
         ets_report['tests'] = results
         ets_report['datetime'] = get_current_datetime_rfc3339()
+        ets_report['metadata_id'] = self.record['id']
 
-        return {
-            'ets-report': ets_report
-        }
+        return ets_report
 
     def test_requirement_validation(self):
         """

--- a/pywcmp/wcmp2/kpi.py
+++ b/pywcmp/wcmp2/kpi.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2023 Tom Kralidis
+# Copyright (c) 2024 Tom Kralidis
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -28,6 +28,7 @@
 import logging
 import mimetypes
 import re
+import uuid
 
 from bs4 import BeautifulSoup
 
@@ -39,6 +40,18 @@ LOGGER = logging.getLogger(__name__)
 
 # round percentages to x decimal places
 ROUND = 3
+
+
+def gen_test_id(test_id: str) -> str:
+    """
+    Convenience function to print test identifier as URI
+
+    :param test_id: test suite identifier
+
+    :returns: test identifier as URI
+    """
+
+    return f'http://wis.wmo.int/spec/wcmp/2/kpi/core/{test_id}'
 
 
 class WMOCoreMetadataProfileKeyPerformanceIndicators:
@@ -70,7 +83,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         """
         Implements KPI for Good quality title
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -78,10 +91,11 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         score = 0
         comments = []
 
-        name = 'KPI: Good quality title'
+        id_ = gen_test_id('good_quality_title')
+        title = 'Good quality title'
         acronym_regex = r'\b([A-Z]{2,}\d*)\b'
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         title = self.data['properties']['title']
 
@@ -146,13 +160,13 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         else:
             comments.append(f'Title contains spelling errors {misspelled}')
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def kpi_description(self) -> tuple:
         """
         Implements KPI for Good quality description
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -160,9 +174,10 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         score = 0
         comments = []
 
-        name = 'KPI: Good quality description'
+        id_ = gen_test_id('good_quality_description')
+        title = ': Good quality description'
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         description = self.data['properties']['description']
 
@@ -198,13 +213,13 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         else:
             comments.append(f'Description contains spelling errors {misspelled}')  # noqa
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def kpi_time_intervals(self) -> tuple:
         """
         Implements KPI for Time intervals
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -214,15 +229,16 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         score = 0
         comments = []
 
-        name = 'KPI: Time intervals'
+        id_ = gen_test_id('time_intervals')
+        title = 'Time intervals'
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         time_ = self.data.get('time')
         if time_ is None:
             msg = 'time is null; no KPI check'
             LOGGER.debug(msg)
-            return name, 0, 0, [msg]
+            return id_, title, 0, 0, [msg]
 
         interval = self.data['time'].get('interval')
 
@@ -258,13 +274,13 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
             else:
                 comments.append('No temporal resolution found')
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def kpi_graphic_overview(self) -> tuple:
         """
         Implements KPI for Graphic overview for metadata records
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -282,9 +298,10 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
             'image/webp'
         ]
 
-        name = 'KPI: Graphic overview for metadata records'
+        id_ = gen_test_id('graphic_overview_for_metadata_records')
+        title = 'Graphic overview for metadata records'
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         for link in self.data['links']:
             if link.get('rel') == 'preview':
@@ -308,13 +325,13 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
                 else:
                     comments.append(f"URL not accessible: {link['href']}")
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def kpi_links_health(self) -> tuple:
         """
         Implements KPI for Links health
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -324,7 +341,8 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         score = 0
         comments = []
 
-        name = 'KPI: Links health'
+        id_ = gen_test_id('links_health')
+        title = 'Links health'
 
         valid_link_mime_types = list(mimetypes.types_map.values())
         valid_link_mime_types.extend([
@@ -333,7 +351,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
             'text/turtle'
         ])
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         LOGGER.debug('Assembling all links')
 
@@ -384,13 +402,13 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
                 else:
                     comments.append(f"invalid link type {link_type}")
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def kpi_contacts(self) -> tuple:
         """
         Implements KPI for Contacts
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -401,9 +419,10 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         score = 0
         comments = []
 
-        name = 'KPI: Contacts'
+        id_ = gen_test_id('contacts')
+        title = 'Contacts'
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         for contact in self.data['properties']['contacts']:
             if 'host' in contact['roles']:
@@ -429,13 +448,13 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
             else:
                 comments.append('No host contact email found')
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def kpi_pids(self) -> tuple:
         """
         Implements KPI for Persistent identifiers
 
-        :returns: `tuple` of KPI name, achieved score, total score,
+        :returns: `tuple` of KPI id, title, achieved score, total score,
                   and comments
         """
 
@@ -445,9 +464,10 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         score = 0
         comments = []
 
-        name = 'KPI: Persistent identifiers'
+        id_ = gen_test_id('persistent_identifiers')
+        title = 'Persistent identifiers'
 
-        LOGGER.info(f'Running {name}')
+        LOGGER.info(f'Running {title}')
 
         if 'externalIds' in self.data['properties']:
             total = 3
@@ -467,7 +487,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
                 score += 1
                 break
 
-        return name, total, score, comments
+        return id_, title, total, score, comments
 
     def evaluate(self, kpi: str = None) -> dict:
         """
@@ -498,7 +518,14 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
 
         LOGGER.info(f'Evaluating KPIs: {kpis_to_run}')
 
-        results = {}
+        results = {
+            'id': str(uuid.uuid4()),
+            'report_type': 'kpi',
+            'metadata_id': self.identifier,
+            'datetime': get_current_datetime_rfc3339(),
+            'generated_by': f'pywcmp {pywcmp.__version__} (https://github.com/wmo-im/pywcmp)',  # noqa
+            'tests': []
+        }
 
         for kpi in kpis_to_run:
             LOGGER.debug(f'Running {kpi}')
@@ -506,29 +533,26 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
             LOGGER.debug(f'Raw result: {result}')
             LOGGER.debug('Calculating result')
             try:
-                percentage = round(float((result[2] / result[1]) * 100), ROUND)
+                percentage = round(float((result[3] / result[2]) * 100), ROUND)
             except ZeroDivisionError:
                 percentage = None
 
-            results[kpi] = {
-                'name': result[0],
-                'total': result[1],
-                'score': result[2],
-                'comments': result[3],
+            results['tests'].append({
+                'id': result[0],
+                'title': result[1],
+                'total': result[2],
+                'score': result[3],
+                'comments': result[4],
                 'percentage': percentage
-            }
-            LOGGER.debug(f'{kpi}: {result[1]} / {result[2]} = {percentage}')
+            })
+            LOGGER.debug(f'{kpi}: {result[2]} / {result[3]} = {percentage}')
 
         LOGGER.debug('Calculating total results')
         results['summary'] = generate_summary(results)
         # this total summary needs extra elements
-        results['summary']['identifier'] = self.identifier
         overall_grade = 'F'
         overall_grade = calculate_grade(results['summary']['percentage'])
         results['summary']['grade'] = overall_grade
-
-        results['datetime'] = get_current_datetime_rfc3339()
-        results['generated-by'] = f'pywcmp {pywcmp.__version__} (https://github.com/wmo-im/pywcmp)'  # noqa
 
         return results
 
@@ -542,9 +566,14 @@ def generate_summary(results: dict) -> dict:
     :returns: `dict` of summary report
     """
 
-    sum_total = sum(v['total'] for v in results.values())
-    sum_score = sum(v['score'] for v in results.values())
-    comments = {k: v['comments'] for k, v in results.items() if v['comments']}
+    sum_total = sum(v['total'] for v in results['tests'])
+    sum_score = sum(v['score'] for v in results['tests'])
+    comments = {}
+
+    for test in results['tests']:
+        if test['comments']:
+            for k, v in test.items():
+                comments[k] = v
 
     try:
         sum_percentage = round(float((sum_score / sum_total) * 100), ROUND)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -139,7 +139,7 @@ class WCMP2ETSTest(unittest.TestCase):
             ts = WMOCoreMetadataProfileTestSuite2(record)
             results = ts.run_tests()
 
-            codes = [r['code'] for r in results['ets-report']['tests']]
+            codes = [r['code'] for r in results['tests']]
 
             self.assertEqual(codes.count('FAILED'), 1)
             self.assertEqual(codes.count('PASSED'), 11)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -60,14 +60,19 @@ class WCMP2ETSTest(unittest.TestCase):
         """Simple tests for a passing record"""
 
         with open(get_test_file_path('data/wcmp2-passing.json')) as fh:
-            ts = WMOCoreMetadataProfileTestSuite2(json.load(fh))
-            results = ts.run_tests()
+            data = json.load(fh)
 
-            codes = [r['code'] for r in results['ets-report']['tests']]
+        ts = WMOCoreMetadataProfileTestSuite2(data)
+        results = ts.run_tests()
 
-            self.assertEqual(codes.count('FAILED'), 0)
-            self.assertEqual(codes.count('PASSED'), 12)
-            self.assertEqual(codes.count('SKIPPED'), 0)
+        self.assertEqual(results['report_type'], 'ets')
+        self.assertEqual(results['metadata_id'], data['id'])
+
+        codes = [r['code'] for r in results['tests']]
+
+        self.assertEqual(codes.count('FAILED'), 0)
+        self.assertEqual(codes.count('PASSED'), 12)
+        self.assertEqual(codes.count('SKIPPED'), 0)
 
     def test_centre_id(self):
         """Simple tests for a centre-id validation"""
@@ -76,7 +81,7 @@ class WCMP2ETSTest(unittest.TestCase):
             ts = WMOCoreMetadataProfileTestSuite2(json.load(fh))
             results = ts.run_tests()
 
-            codes = [r['code'] for r in results['ets-report']['tests']]
+            codes = [r['code'] for r in results['tests']]
 
             self.assertEqual(codes.count('FAILED'), 0)
             self.assertEqual(codes.count('PASSED'), 12)
@@ -86,7 +91,7 @@ class WCMP2ETSTest(unittest.TestCase):
             ts = WMOCoreMetadataProfileTestSuite2(json.load(fh))
             results = ts.run_tests()
 
-            codes = [r['code'] for r in results['ets-report']['tests']]
+            codes = [r['code'] for r in results['tests']]
 
             self.assertEqual(codes.count('FAILED'), 1)
             self.assertEqual(codes.count('PASSED'), 11)
@@ -100,7 +105,7 @@ class WCMP2ETSTest(unittest.TestCase):
             ts = WMOCoreMetadataProfileTestSuite2(record)
             results = ts.run_tests()
 
-            codes = [r['code'] for r in results['ets-report']['tests']]
+            codes = [r['code'] for r in results['tests']]
 
             self.assertEqual(codes.count('FAILED'), 3)
             self.assertEqual(codes.count('PASSED'), 9)
@@ -117,7 +122,7 @@ class WCMP2ETSTest(unittest.TestCase):
             ts = WMOCoreMetadataProfileTestSuite2(record)
             results = ts.run_tests()
 
-            codes = [r['code'] for r in results['ets-report']['tests']]
+            codes = [r['code'] for r in results['tests']]
 
             self.assertEqual(codes.count('FAILED'), 1)
             self.assertEqual(codes.count('PASSED'), 11)
@@ -162,6 +167,9 @@ class WCMP2KPITest(unittest.TestCase):
         kpis = WMOCoreMetadataProfileKeyPerformanceIndicators(data)
 
         results = kpis.evaluate()
+
+        self.assertEqual(results['report_type'], 'kpi')
+        self.assertEqual(results['metadata_id'], data['id'])
 
         self.assertEqual(results['summary']['total'], 32)
         self.assertEqual(results['summary']['score'], 32)


### PR DESCRIPTION
This PR further aligns ETS and KPI report output formats:

- adds report UUID (`id`)
- removes `ets-report` or `kpi-report` top level element in lieu of `report_type` (`ets` | `kpi`)
- snake case property names
- define / emit KPI URIs

Note: PR #121 should be reviewed/merged first, then I will rebase this PR before final review/merge.

Output report examples below:

ETS:
```json
{
    "id": "ee305ee4-8aa4-41f4-a338-74025d384b5d",
    "report_type": "ets",
    "summary": {
        "PASSED": 12,
        "FAILED": 0,
        "SKIPPED": 0
    },
    "generated_by": "pywcmp 0.10.dev0 (https://github.com/wmo-im/pywcmp)",
    "tests": [
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/conformance",
            "code": "PASSED",
            "message": "Passes given schema is compliant/valid"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/contacts",
            "code": "PASSED"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/record_created_datetime",
            "code": "PASSED"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/data_policy",
            "code": "PASSED"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/description",
            "code": "PASSED",
            "message": "Passes given schema is compliant/valid"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/extent_geospatial",
            "code": "PASSED",
            "message": "Passes given schema is compliant/valid"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/extent_temporal",
            "code": "PASSED",
            "message": "Passes given schema is compliant/valid"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/identifier",
            "code": "PASSED"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/links",
            "code": "PASSED"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/themes",
            "code": "PASSED"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/title",
            "code": "PASSED",
            "message": "Passes given schema is compliant/valid"
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/conf/core/type",
            "code": "PASSED"
        }
    ],
    "datetime": "2024-08-25T14:56:40Z",
    "metadata_id": "urn:wmo:md:ca-eccc-msc:weather.observations.swob-realtime"
}
```

KPI:
```json
{
    "id": "6bea2459-1dde-4fd9-b5cc-c6788052d2d3",
    "report_type": "kpi",
    "metadata_id": "urn:wmo:md:ca-eccc-msc:weather.observations.swob-realtime",
    "datetime": "2024-08-25T14:57:12Z",
    "generated_by": "pywcmp 0.10.dev0 (https://github.com/wmo-im/pywcmp)",
    "tests": [
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/contacts",
            "title": "Contacts",
            "total": 3,
            "score": 3,
            "comments": [],
            "percentage": 100.0
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/good_quality_description",
            "title": ": Good quality description",
            "total": 4,
            "score": 4,
            "comments": [],
            "percentage": 100.0
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/graphic_overview_for_metadata_records",
            "title": "Graphic overview for metadata records",
            "total": 0,
            "score": 0,
            "comments": [],
            "percentage": null
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/links_health",
            "title": "Links health",
            "total": 14,
            "score": 14,
            "comments": [],
            "percentage": 100.0
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/persistent_identifiers",
            "title": "Persistent identifiers",
            "total": 0,
            "score": 0,
            "comments": [],
            "percentage": null
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/time_intervals",
            "title": "Time intervals",
            "total": 3,
            "score": 3,
            "comments": [],
            "percentage": 100.0
        },
        {
            "id": "http://wis.wmo.int/spec/wcmp/2/kpi/core/good_quality_title",
            "title": "Surface weather observations",
            "total": 8,
            "score": 8,
            "comments": [],
            "percentage": 100.0
        }
    ],
    "summary": {
        "total": 32,
        "score": 32,
        "comments": {},
        "percentage": 100.0,
        "grade": "A"
    }
}
```