### PR TITLE
fix tests

### DIFF
--- a/pywcmp/resources/example-ca-eccc-msc.nwp-gdps.json
+++ b/pywcmp/resources/example-ca-eccc-msc.nwp-gdps.json
@@ -124,19 +124,6 @@
     },
     "links": [
         {
-            "rel": "data",
-            "href": "https://dd.weather.gc.ca/model_gem_global",
-            "type": "text/html",
-            "title": "MSC Datamart",
-            "distribution": {
-                "availableFormats": [
-                    {
-                        "name": "GRIB2"
-                    }
-                ]
-            }
-        },
-        {
             "rel": "license",
             "href": "https://open.canada.ca/en/open-government-licence-canada",
             "type": "text/html",
@@ -154,6 +141,20 @@
             "href": "mqtts://everyone:everyone@globalbroker.meteo.fr:8883",
             "type": "application/geo+json",
             "title": "Data notifications"
+        }
+    ],
+    "linkTemplates": [
+        {
+            "rel": "data",
+            "type": "text/html",
+            "title": "MSC Datamart",
+            "uriTemplate": "https://dd.weather.gc.ca/{yyyymmdd}/WXO-DD/model_gem_global",
+            "variables": {
+                "yyyymmdd": {
+                    "type": "string",
+                    "description": "date in yyyymmdd format"
+                }
+            }
         }
     ]
 }

--- a/tests/data/wcmp2-passing.json
+++ b/tests/data/wcmp2-passing.json
@@ -126,19 +126,6 @@
     },
     "links": [
         {
-            "rel": "stations",
-            "href": "https://dd.weather.gc.ca/observations/doc/swob-xml_station_list.csv",
-            "type": "text/csv",
-            "title": "Stations associated with this dataset"
-        },
-        {
-            "rel": "data",
-            "href": "https://dd.weather.gc.ca/observations/swob-ml",
-            "type": "text/html",
-            "hreflang": "en",
-            "title": "Raw data download (CSV files)"
-        },
-        {
             "rel": "items",
             "href": "https://api.weather.gc.ca/collections/swob-realtime/items",
             "type": "application/json",
@@ -156,6 +143,33 @@
             "channel": "origin/a/wis2/ca-eccc-msc/data/core/weather/experimental/surface-based-observations/synop",
             "type": "application/json",
             "title": "Data notifications"
+        }
+    ],
+    "linkTemplates": [
+        {
+            "rel": "stations",
+            "type": "text/csv",
+            "title": "Stations associated with this dataset",
+            "uriTemplate": "https://dd.weather.gc.ca/{yyyymmdd}/WXO-DD/observations/doc/swob-xml_station_list.csv",
+            "variables": {
+                "yyyymmdd": {
+                    "type": "string",
+                    "description": "date in yyyymmdd format"
+                }
+            }
+        },
+        {
+            "rel": "data",
+            "type": "text/csv",
+            "hreflang": "en",
+            "title": "Raw data download (CSV files)",
+            "uriTemplate": "https://dd.weather.gc.ca/{yyyymmdd}/WXO-DD/observations/swob-ml",
+            "variables": {
+                "yyyymmdd": {
+                    "type": "string",
+                    "description": "date in yyyymmdd format"
+                }
+            }
         }
     ]
 }

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -308,8 +308,8 @@ class WCMP2KPITest(unittest.TestCase):
         self.assertEqual(results['report_type'], 'kpi')
         self.assertEqual(results['metadata_id'], data['id'])
 
-        self.assertEqual(results['summary']['total'], 32)
-        self.assertEqual(results['summary']['score'], 32)
+        self.assertEqual(results['summary']['total'], 28)
+        self.assertEqual(results['summary']['score'], 28)
         self.assertEqual(results['summary']['percentage'], 100)
         self.assertEqual(results['summary']['grade'], 'A')
 


### PR DESCRIPTION
Some test / records are updated to reflect [recent changes in the ECCC/MSC Datamart service](https://comm.collab.science.gc.ca/mailman3/hyperkitty/list/dd_info@comm.collab.science.gc.ca/thread/KUTI2MD2DDIQC5MVPJWZZ3TIGFNFEKME/), thus making some link objects as link templates.