### PR TITLE
do not validate channel for MQTT rel=hub links

### DIFF
--- a/pywcmp/wcmp2/ets.py
+++ b/pywcmp/wcmp2/ets.py
@@ -515,9 +515,12 @@ class WMOCoreMetadataProfileTestSuite2:
             LOGGER.debug('Checking that Pub/Sub links have a valid channel')
             if link['href'].startswith(('mqtt', 'ws')):
                 if 'channel' not in link:
-                    status['code'] = 'FAILED'
-                    status['message'] = 'missing channel for Pub/Sub link'
-                    return status
+                    if link.get('rel') == 'hub':
+                        continue
+                    else:
+                        status['code'] = 'FAILED'
+                        status['message'] = 'missing channel for Pub/Sub link'
+                        return status
 
                 if link['channel'].startswith(('origin/a/wis2', 'cache/a/wis2')):  # noqa
                     channel_tokens = link['channel'].split('/')


### PR DESCRIPTION
This PR skips channel validation for MQTT links if the link object is a `rel=hub` link, denoting a link of the entire instance instead of a specific dataset/channel.

`rel=hub` is defined for MQP service link identification in [OGC API Publish-Subscribe Workflow - Part 1: Core](https://docs.ogc.org/DRAFTS/25-030.html#_3e312cb7-1812-0caf-b774-ae52f17ded6f) (draft).