### PR TITLE
KPI: update title scoring, fix ref for additionalExtents.temporal

### DIFF
--- a/pywcmp/wcmp2/kpi.py
+++ b/pywcmp/wcmp2/kpi.py
@@ -99,7 +99,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
                   and comments
         """
 
-        total = 8
+        total = 7
         score = 0
         comments = []
 
@@ -111,8 +111,6 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
 
         title = self.data['properties']['title']
 
-        LOGGER.debug('Title is present')
-        score += 1
         title_words = []
 
         try:

--- a/pywcmp/wcmp2/kpi.py
+++ b/pywcmp/wcmp2/kpi.py
@@ -258,7 +258,7 @@ class WMOCoreMetadataProfileKeyPerformanceIndicators:
         try:
             if self.data['additionalExtents']['temporal']['interval'] is not None:  # noqa
                 time_intervals.append(
-                    self.data['additionalExtents']['temporal'])
+                    self.data['additionalExtents']['temporal'][0])
         except KeyError:
             pass
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -358,8 +358,8 @@ class WCMP2KPITest(unittest.TestCase):
 
                 self.assertEqual(results['report_type'], 'kpi')
                 self.assertEqual(results['metadata_id'], data['id'])
-                self.assertEqual(results['summary']['total'], 29)
-                self.assertEqual(results['summary']['score'], 29)
+                self.assertEqual(results['summary']['total'], 28)
+                self.assertEqual(results['summary']['score'], 28)
 
     def test_kpi_evaluate(self):
         """Tests for KPI evaluation"""
@@ -375,8 +375,8 @@ class WCMP2KPITest(unittest.TestCase):
         self.assertEqual(results['report_type'], 'kpi')
         self.assertEqual(results['metadata_id'], data['id'])
 
-        self.assertEqual(results['summary']['total'], 29)
-        self.assertEqual(results['summary']['score'], 29)
+        self.assertEqual(results['summary']['total'], 28)
+        self.assertEqual(results['summary']['score'], 28)
         self.assertEqual(results['summary']['percentage'], 100)
         self.assertEqual(results['summary']['grade'], 'A')
 


### PR DESCRIPTION
- remove properties.title presence as a score, given it is required for compliance (ref: https://github.com/wmo-im/wcmp2/pull/308
- fix ref for `additionalExtents.temporal` (array of arrays)